### PR TITLE
Add: Ability to configure a different mysql host for transient archival

### DIFF
--- a/db-archiver-config.yml.sample
+++ b/db-archiver-config.yml.sample
@@ -1,6 +1,7 @@
 # This is a template, copy the contents of this file to db-archiver-config.yml
 database_config:
-    host: mysql-5.6
+    host: mysql_host
+    archive_host: mysql_archive_host
     user: mysql_user
     password: mysql_pass
     database: my_test_database

--- a/src/db_archiver.py
+++ b/src/db_archiver.py
@@ -61,7 +61,8 @@ def start_archival():
     db_name = database_config.get('database')
     transaction_size = database_config.get('transaction_size')
     logging.info('Starting archive...')
-    archive(host, archive_host, db_name, table_name, where_clause, column_name_to_log_in_file, transaction_size, optimize)
+    archive(host, archive_host, db_name, table_name, where_clause, column_name_to_log_in_file, transaction_size,
+            optimize)
 
 
 def archive(host, archive_host, db_name, table_name, where_clause, column_name_to_log_in_file,
@@ -78,15 +79,15 @@ def archive(host, archive_host, db_name, table_name, where_clause, column_name_t
     try:
         db_utils.create_archive_table(
             db_name, table_name, archive_db_name, archive_table_name)
-    except ProgrammingError as e:
-        if e.errno == 1050:
+    except ProgrammingError as er:
+        if er.errno == 1050:
             logging.info(
                 f'Archive table {archive_db_name}.{archive_table_name} exists,'
                 f' archiving older rows'
             )
 
             fetch_archived_data_upload_to_s3_and_delete(
-                host, archive_host, db_name, table_name, archive_db_name, archive_table_name,
+                archive_host, db_name, table_name, archive_db_name, archive_table_name,
                 column_name_to_log_in_file, transaction_size, '')
 
             archive(host, archive_host, db_name, table_name, where_clause,
@@ -94,20 +95,20 @@ def archive(host, archive_host, db_name, table_name, where_clause, column_name_t
 
             return None
         else:
-            raise e
+            raise er
 
     archive_utils.archive_to_db(
         host, archive_host, db_name, table_name, archive_db_name, archive_table_name, where_clause,
         transaction_size, optimize)
 
     fetch_archived_data_upload_to_s3_and_delete(
-        host, archive_host, db_name, table_name, archive_db_name, archive_table_name,
+        archive_host, db_name, table_name, archive_db_name, archive_table_name,
         column_name_to_log_in_file, transaction_size, where_clause)
 
 
 def fetch_archived_data_upload_to_s3_and_delete(
-    host, archive_host, db_name, table_name, archive_db_name, archive_table_name,
-    column_name_to_log_in_file, transaction_size, where_clause):
+        archive_host, db_name, table_name, archive_db_name, archive_table_name,
+        column_name_to_log_in_file, transaction_size, where_clause):
     no_of_rows_archived = db_utils.get_count_of_rows_archived(
         archive_db_name, archive_table_name)
     if not no_of_rows_archived:
@@ -141,7 +142,7 @@ def fetch_archived_data_upload_to_s3_and_delete(
 
 def compress_to_gzip(local_file_name):
     gzip_file_name = f'{local_file_name}.gz'
-    fp = open(local_file_name,'rb')
+    fp = open(local_file_name, 'rb')
     with gzip.open(gzip_file_name, 'wb') as gz_fp:
         gz_fp.write(bytearray(fp.read()))
 

--- a/src/db_archiver.py
+++ b/src/db_archiver.py
@@ -56,13 +56,15 @@ def start_archival():
             f' These are mandatory values.'
         )
 
+    host = database_config.get('host')
+    archive_host = database_config.get('archive_host')
     db_name = database_config.get('database')
     transaction_size = database_config.get('transaction_size')
     logging.info('Starting archive...')
-    archive(db_name, table_name, where_clause, column_name_to_log_in_file, transaction_size, optimize)
+    archive(host, archive_host, db_name, table_name, where_clause, column_name_to_log_in_file, transaction_size, optimize)
 
 
-def archive(db_name, table_name, where_clause, column_name_to_log_in_file,
+def archive(host, archive_host, db_name, table_name, where_clause, column_name_to_log_in_file,
             transaction_size, optimize):
     logging.info('')
     logging.info('')
@@ -84,10 +86,10 @@ def archive(db_name, table_name, where_clause, column_name_to_log_in_file,
             )
 
             fetch_archived_data_upload_to_s3_and_delete(
-                db_name, table_name, archive_db_name, archive_table_name,
+                host, archive_host, db_name, table_name, archive_db_name, archive_table_name,
                 column_name_to_log_in_file, transaction_size, '')
 
-            archive(db_name, table_name, where_clause,
+            archive(host, archive_host, db_name, table_name, where_clause,
                     column_name_to_log_in_file, transaction_size, optimize)
 
             return None
@@ -95,16 +97,16 @@ def archive(db_name, table_name, where_clause, column_name_to_log_in_file,
             raise e
 
     archive_utils.archive_to_db(
-        db_name, table_name, archive_db_name, archive_table_name, where_clause,
+        host, archive_host, db_name, table_name, archive_db_name, archive_table_name, where_clause,
         transaction_size, optimize)
 
     fetch_archived_data_upload_to_s3_and_delete(
-        db_name, table_name, archive_db_name, archive_table_name,
+        host, archive_host, db_name, table_name, archive_db_name, archive_table_name,
         column_name_to_log_in_file, transaction_size, where_clause)
 
 
 def fetch_archived_data_upload_to_s3_and_delete(
-    db_name, table_name, archive_db_name, archive_table_name,
+    host, archive_host, db_name, table_name, archive_db_name, archive_table_name,
     column_name_to_log_in_file, transaction_size, where_clause):
     no_of_rows_archived = db_utils.get_count_of_rows_archived(
         archive_db_name, archive_table_name)
@@ -121,7 +123,7 @@ def fetch_archived_data_upload_to_s3_and_delete(
         column_name_to_log_in_file, where_clause)
 
     archive_utils.archive_to_file(
-        archive_db_name, archive_table_name, transaction_size, local_file_name)
+        archive_host, archive_db_name, archive_table_name, transaction_size, local_file_name)
 
     gzip_file_name = compress_to_gzip(local_file_name)
     gzip_s3_path = f'{s3_path}.gz'

--- a/src/db_utils.py
+++ b/src/db_utils.py
@@ -9,38 +9,41 @@ MYSQL_CONNECTION_STRING = 'mysql://{user}:{password}@{host}'
 db_user = database_config.get('user')
 db_password = database_config.get('password')
 db_host = database_config.get('host')
+archive_host = database_config.get('archive_host')
 
-mysql_connection = mysql.connector.connect(
-    host=db_host, user=db_user, password=db_password)
-mysql_cursor = mysql_connection.cursor(dictionary=True)
+source_mysql_connection = mysql.connector.connect(host=db_host, user=db_user, password=db_password)
+source_mysql_cursor = source_mysql_connection.cursor(dictionary=True)
+
+dest_mysql_connection = mysql.connector.connect(host=archive_host, user=db_user, password=db_password)
+dest_mysql_cursor = dest_mysql_connection.cursor(dictionary=True)
 
 
 def create_archive_database(db_name, archive_db_name):
-    mysql_cursor.execute(
+    dest_mysql_cursor.execute(
         f'SELECT SCHEMA_NAME '
         f'FROM INFORMATION_SCHEMA.SCHEMATA '
         f'WHERE SCHEMA_NAME = \'{archive_db_name}\''
     )
-    result = mysql_cursor.fetchone()
+    result = dest_mysql_cursor.fetchone()
 
     if result is None:
-        mysql_cursor.execute(f'SHOW CREATE DATABASE {db_name}')
-        create_db_query = mysql_cursor.fetchone()['Create Database']
+        source_mysql_cursor.execute(f'SHOW CREATE DATABASE {db_name}')
+        create_db_query = source_mysql_cursor.fetchone()['Create Database']
         create_archive_db_query = re.sub(
             r'(?s)(CREATE DATABASE )(`.*?)(`)',
             r'\1IF NOT EXISTS `' + archive_db_name + '`',
             create_db_query,
             count=1
         )
-        mysql_cursor.execute(create_archive_db_query)
+        dest_mysql_cursor.execute(create_archive_db_query)
         logging.info(f'Created archive database {archive_db_name}')
 
 
 def create_archive_table(db_name, table_name, archive_db_name,
                          archive_table_name):
-    mysql_cursor.execute(f'USE {db_name}')
-    mysql_cursor.execute(f'SHOW CREATE TABLE {table_name}')
-    create_table_query = mysql_cursor.fetchone()['Create Table']
+    source_mysql_cursor.execute(f'USE {db_name}')
+    source_mysql_cursor.execute(f'SHOW CREATE TABLE {table_name}')
+    create_table_query = source_mysql_cursor.fetchone()['Create Table']
 
     create_archive_table_query_list = []
     for line in create_table_query.splitlines():
@@ -70,48 +73,48 @@ def create_archive_table(db_name, table_name, archive_db_name,
     create_archive_table_query_list[remove_comma_line_no] = remove_comma_line
     create_archive_table_query = ' '.join(create_archive_table_query_list)
 
-    mysql_cursor.execute(f'USE {archive_db_name}')
-    mysql_cursor.execute(create_archive_table_query)
+    dest_mysql_cursor.execute(f'USE {archive_db_name}')
+    dest_mysql_cursor.execute(create_archive_table_query)
     logging.info(
         f'Created archive table {archive_db_name}.{archive_table_name}')
 
 
 def drop_archive_table(archive_db_name, archive_table_name):
-    mysql_cursor.execute(f'USE {archive_db_name}')
-    mysql_cursor.execute(f'DROP TABLE {archive_table_name}')
+    dest_mysql_cursor.execute(f'USE {archive_db_name}')
+    dest_mysql_cursor.execute(f'DROP TABLE {archive_table_name}')
     logging.info('')
     logging.info('')
     logging.info(f'Dropped archive table {archive_db_name}.{archive_table_name}')
 
 
 def get_count_of_rows_archived(archive_db_name, archive_table_name):
-    mysql_cursor.execute(
+    dest_mysql_cursor.execute(
         f'SELECT count(*) as count '
         f'FROM {archive_db_name}.{archive_table_name}'
     )
 
-    return mysql_cursor.fetchone()['count']
+    return dest_mysql_cursor.fetchone()['count']
 
 
 def get_file_names(db_name, table_name, archive_db_name, archive_table_name,
                    column_name, where_clause):
 
-    mysql_cursor.execute(
+    dest_mysql_cursor.execute(
         f'SELECT {column_name} as first_value '
         f'FROM {archive_db_name}.{archive_table_name} '
         f'ORDER BY {column_name} '
         f'LIMIT 1'
     )
-    first_value = mysql_cursor.fetchone()['first_value']
+    first_value = dest_mysql_cursor.fetchone()['first_value']
     first_value = str(first_value)
 
-    mysql_cursor.execute(
+    dest_mysql_cursor.execute(
         f'SELECT {column_name} as last_value '
         f'FROM {archive_db_name}.{archive_table_name} '
         f'ORDER BY {column_name} DESC '
         f'LIMIT 1'
     )
-    last_value = mysql_cursor.fetchone()['last_value']
+    last_value = dest_mysql_cursor.fetchone()['last_value']
     last_value = str(last_value)
 
     data_part_name = f'({column_name})_from_({first_value})_to_({last_value})'


### PR DESCRIPTION
### What?
Add ability to configure a different mysql host for transient archival

### Why?
So that primary RDS is not overloaded with DB to DB data move operation

### How?
By configuring different values for `host` and `archive_host`in `db-archiver-config.yml`